### PR TITLE
Use --allow-downgrade

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,6 @@ runs:
         if(Test-path c:\\rtools40){
           echo "rtools40 is preinstalled"
         } else {
-          choco install --confirm --no-progress --side-by-side rtools --version ${{inputs.version}}
+          choco install --confirm --no-progress --allow-downgrade rtools --version ${{inputs.version}}
         }
         echo "c:\\rtools40\\usr\\bin" >> $GITHUB_PATH


### PR DESCRIPTION
Chocolatey 2.0 (now rolling out to images) no longer supports --side-by-side 🤷 
```
Chocolatey v2.0.0
The --side-by-side option is no longer supported.
...
Failures
 - rtools - A newer version of rtools (v4.3.5550) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
```